### PR TITLE
Replace hardcoded path separators with `File.separator`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,14 +32,6 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,29 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <finalName>TestSmellDetector</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <archive>
+                        <manifest>
+                            <mainClass>Main</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/src/main/java/testsmell/TestFile.java
+++ b/src/main/java/testsmell/TestFile.java
@@ -42,8 +42,7 @@ public class TestFile {
     }
 
     public String getTagName(){
-        String[] splittud = testFilePath.split(String.format("\\%s", File.separator));
-        return splittud[4];
+        return testFilePath.split(String.format("\\%s", File.separator))[4];
     }
 
     public String getTestFileName(){

--- a/src/main/java/testsmell/TestFile.java
+++ b/src/main/java/testsmell/TestFile.java
@@ -2,6 +2,7 @@ package testsmell;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,11 +42,12 @@ public class TestFile {
     }
 
     public String getTagName(){
-        return testFilePath.split("\\\\")[4];
+        String[] splittud = testFilePath.split(String.format("\\%s", File.separator));
+        return splittud[4];
     }
 
     public String getTestFileName(){
-        int lastIndex = testFilePath.lastIndexOf("\\");
+        int lastIndex = testFilePath.lastIndexOf(File.separator);
         return testFilePath.substring(lastIndex+1,testFilePath.length());
     }
 
@@ -62,29 +64,29 @@ public class TestFile {
     }
 
     public String getProductionFileName(){
-        int lastIndex = productionFilePath.lastIndexOf("\\");
+        int lastIndex = productionFilePath.lastIndexOf(File.separator);
         if(lastIndex==-1)
             return "";
         return productionFilePath.substring(lastIndex+1,productionFilePath.length());
     }
 
     public String getRelativeTestFilePath() {
-        String[] splitString = testFilePath.split("\\\\");
+        String[] splitString = testFilePath.split(String.format("\\%s", File.separator));
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < 5; i++) {
-            stringBuilder.append(splitString[i] + "\\");
+            stringBuilder.append(splitString[i] + File.separator);
         }
-        return testFilePath.substring(stringBuilder.toString().length()).replace("\\", "/");
+        return testFilePath.substring(stringBuilder.toString().length()).replace(File.separator, "/");
     }
 
     public String getRelativeProductionFilePath() {
         if (!StringUtils.isEmpty(productionFilePath)) {
-            String[] splitString = productionFilePath.split("\\\\");
+            String[] splitString = productionFilePath.split(String.format("\\%s", File.separator));
             StringBuilder stringBuilder = new StringBuilder();
             for (int i = 0; i < 5; i++) {
-                stringBuilder.append(splitString[i] + "\\");
+                stringBuilder.append(splitString[i] + File.separator);
             }
-            return productionFilePath.substring(stringBuilder.toString().length()).replace("\\", "/");
+            return productionFilePath.substring(stringBuilder.toString().length()).replace(File.separator, "/");
         } else {
             return "";
 


### PR DESCRIPTION
Replaces all occurrences of `"\\"` and `"\\\\"` with their respective `File.separator` counterparts to make the project run on multiple platforms.

(Also adds [maven-assembly-plugin](http://maven.apache.org/plugins/maven-assembly-plugin/) for easy compilation to JAR)