### PR TITLE
Update JavaParser version and fix configured smells being ignored

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.2.4</version>
+            <version>3.24.4</version>
         </dependency>
         <dependency>
             <groupId>com.opencsv</groupId>

--- a/src/main/java/testsmell/SmellFactory.java
+++ b/src/main/java/testsmell/SmellFactory.java
@@ -1,0 +1,8 @@
+package testsmell;
+
+import thresholds.Thresholds;
+
+@FunctionalInterface
+public interface SmellFactory {
+    AbstractSmell createInstance(Thresholds thresholds);
+}

--- a/src/main/java/testsmell/TestSmellDetector.java
+++ b/src/main/java/testsmell/TestSmellDetector.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 public class TestSmellDetector {
 
-    private List<AbstractSmell> testSmells;
+    private List<SmellFactory> testSmells;
     private Thresholds thresholds;
 
     /**
@@ -31,30 +31,30 @@ public class TestSmellDetector {
 
     private void initializeSmells() {
         testSmells = new ArrayList<>();
-        testSmells.add(new AssertionRoulette(thresholds));
-        testSmells.add(new ConditionalTestLogic(thresholds));
-        testSmells.add(new ConstructorInitialization(thresholds));
-        testSmells.add(new DefaultTest(thresholds));
-        testSmells.add(new EmptyTest(thresholds));
-        testSmells.add(new ExceptionCatchingThrowing(thresholds));
-        testSmells.add(new GeneralFixture(thresholds));
-        testSmells.add(new MysteryGuest(thresholds));
-        testSmells.add(new PrintStatement(thresholds));
-        testSmells.add(new RedundantAssertion(thresholds));
-        testSmells.add(new SensitiveEquality(thresholds));
-        testSmells.add(new VerboseTest(thresholds));
-        testSmells.add(new SleepyTest(thresholds));
-        testSmells.add(new EagerTest(thresholds));
-        testSmells.add(new LazyTest(thresholds));
-        testSmells.add(new DuplicateAssert(thresholds));
-        testSmells.add(new UnknownTest(thresholds));
-        testSmells.add(new IgnoredTest(thresholds));
-        testSmells.add(new ResourceOptimism(thresholds));
-        testSmells.add(new MagicNumberTest(thresholds));
-        testSmells.add(new DependentTest(thresholds));
+        testSmells.add(AssertionRoulette::new);
+        testSmells.add(ConditionalTestLogic::new);
+        testSmells.add(ConstructorInitialization::new);
+        testSmells.add(DefaultTest::new);
+        testSmells.add(EmptyTest::new);
+        testSmells.add(ExceptionCatchingThrowing::new);
+        testSmells.add(GeneralFixture::new);
+        testSmells.add(MysteryGuest::new);
+        testSmells.add(PrintStatement::new);
+        testSmells.add(RedundantAssertion::new);
+        testSmells.add(SensitiveEquality::new);
+        testSmells.add(VerboseTest::new);
+        testSmells.add(SleepyTest::new);
+        testSmells.add(EagerTest::new);
+        testSmells.add(LazyTest::new);
+        testSmells.add(DuplicateAssert::new);
+        testSmells.add(UnknownTest::new);
+        testSmells.add(IgnoredTest::new);
+        testSmells.add(ResourceOptimism::new);
+        testSmells.add(MagicNumberTest::new);
+        testSmells.add(DependentTest::new);
     }
 
-    public void setTestSmells(List<AbstractSmell> testSmells) {
+    public void setTestSmells(List<SmellFactory> testSmells) {
         this.testSmells = testSmells;
     }
 
@@ -64,7 +64,10 @@ public class TestSmellDetector {
      * @return list of smell names
      */
     public List<String> getTestSmellNames() {
-        return testSmells.stream().map(AbstractSmell::getSmellName).collect(Collectors.toList());
+        return testSmells.stream()
+            .map(factory -> factory.createInstance(thresholds))
+            .map(AbstractSmell::getSmellName)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -72,7 +75,6 @@ public class TestSmellDetector {
      * test smells
      */
     public TestFile detectSmells(TestFile testFile) throws IOException {
-        initializeSmells();
         CompilationUnit testFileCompilationUnit = null;
         CompilationUnit productionFileCompilationUnit = null;
         FileInputStream testFileInputStream, productionFileInputStream;
@@ -89,7 +91,8 @@ public class TestSmellDetector {
             productionFileCompilationUnit = Util.parseJava(productionFileInputStream);
         }
 
-        for (AbstractSmell smell : testSmells) {
+        for (SmellFactory smellFactory : testSmells) {
+            AbstractSmell smell = smellFactory.createInstance(thresholds);
             try {
                 smell.runAnalysis(testFileCompilationUnit, productionFileCompilationUnit,
                         testFile.getTestFileNameWithoutExtension(),

--- a/src/main/java/testsmell/TestSmellDetector.java
+++ b/src/main/java/testsmell/TestSmellDetector.java
@@ -1,6 +1,5 @@
 package testsmell;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import org.apache.commons.lang3.StringUtils;
@@ -80,14 +79,14 @@ public class TestSmellDetector {
 
         if (!StringUtils.isEmpty(testFile.getTestFilePath())) {
             testFileInputStream = new FileInputStream(testFile.getTestFilePath());
-            testFileCompilationUnit = JavaParser.parse(testFileInputStream);
+            testFileCompilationUnit = Util.parseJava(testFileInputStream);
             TypeDeclaration typeDeclaration = testFileCompilationUnit.getTypes().get(0);
             testFile.setNumberOfTestMethods(typeDeclaration.getMethods().size());
         }
 
         if (!StringUtils.isEmpty(testFile.getProductionFilePath())) {
             productionFileInputStream = new FileInputStream(testFile.getProductionFilePath());
-            productionFileCompilationUnit = JavaParser.parse(productionFileInputStream);
+            productionFileCompilationUnit = Util.parseJava(productionFileInputStream);
         }
 
         for (AbstractSmell smell : testSmells) {

--- a/src/main/java/testsmell/smell/ConditionalTestLogic.java
+++ b/src/main/java/testsmell/smell/ConditionalTestLogic.java
@@ -121,7 +121,7 @@ public class ConditionalTestLogic extends AbstractSmell {
         }
 
         @Override
-        public void visit(ForeachStmt n, Void arg) {
+        public void visit(ForEachStmt n, Void arg) {
             super.visit(n, arg);
             if (currentMethod != null) {
                 foreachCount++;

--- a/src/main/java/testsmell/smell/DependentTest.java
+++ b/src/main/java/testsmell/smell/DependentTest.java
@@ -11,6 +11,8 @@ import thresholds.Thresholds;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DependentTest extends AbstractSmell {
 
@@ -38,8 +40,14 @@ public class DependentTest extends AbstractSmell {
         classVisitor = new DependentTest.ClassVisitor();
         classVisitor.visit(testFileCompilationUnit, null);
 
+        Set<String> testMethodNames = testMethods.stream()
+            .map(method -> method.getMethodDeclaration().getNameAsString())
+            .collect(Collectors.toSet());
+
         for (TestMethod testMethod : testMethods) {
-            if (testMethod.getCalledMethods().stream().anyMatch(x -> x.getName().equals(testMethods.stream().map(z -> z.getMethodDeclaration().getNameAsString())))) {
+            boolean match = testMethod.getCalledMethods()
+                .stream().anyMatch(method -> testMethodNames.contains(method.getName()));
+            if (match) {
                 smellyElementsSet.add(new testsmell.TestMethod(testMethod.getMethodDeclaration().getNameAsString()));
             }
         }

--- a/src/main/java/testsmell/smell/EagerTest.java
+++ b/src/main/java/testsmell/smell/EagerTest.java
@@ -122,7 +122,7 @@ public class EagerTest extends AbstractSmell {
                 }
             } else { //collect a list of all public/protected members of the production class
                 for (Modifier modifier : n.getModifiers()) {
-                    if (modifier.name().toLowerCase().equals("public") || modifier.name().toLowerCase().equals("protected")) {
+                    if (modifier.getKeyword() == Modifier.Keyword.PUBLIC || modifier.getKeyword() == Modifier.Keyword.PROTECTED) {
                         productionMethods.add(n);
                     }
                 }

--- a/src/main/java/testsmell/smell/IgnoredTest.java
+++ b/src/main/java/testsmell/smell/IgnoredTest.java
@@ -78,7 +78,7 @@ public class IgnoredTest extends AbstractSmell {
             //JUnit 3
             //check if test method is not public
             if (n.getNameAsString().toLowerCase().startsWith("test")) {
-                if (!n.getModifiers().contains(Modifier.PUBLIC)) {
+                if (n.getModifiers().stream().noneMatch(m -> m.getKeyword() == Modifier.Keyword.PUBLIC)) {
                     testMethod = new TestMethod(n.getNameAsString());
                     testMethod.setSmell(true);
                     smellyElementsSet.add(testMethod);

--- a/src/main/java/testsmell/smell/LazyTest.java
+++ b/src/main/java/testsmell/smell/LazyTest.java
@@ -138,7 +138,7 @@ public class LazyTest extends AbstractSmell {
                 }
             } else { //collect a list of all public/protected members of the production class
                 for (Modifier modifier : n.getModifiers()) {
-                    if (modifier.name().toLowerCase().equals("public") || modifier.name().toLowerCase().equals("protected")) {
+                    if (modifier.getKeyword() == Modifier.Keyword.PUBLIC || modifier.getKeyword() == Modifier.Keyword.PROTECTED) {
                         productionMethods.add(n);
                     }
                 }

--- a/src/main/java/testsmell/smell/UnknownTest.java
+++ b/src/main/java/testsmell/smell/UnknownTest.java
@@ -1,6 +1,7 @@
 package testsmell.smell;
 
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -55,14 +56,14 @@ public class UnknownTest extends AbstractSmell {
             if (Util.isValidTestMethod(n)) {
                 Optional<AnnotationExpr> assertAnnotation = n.getAnnotationByName("Test");
                 if (assertAnnotation.isPresent()) {
-                    for (int i = 0; i < assertAnnotation.get().getNodeLists().size(); i++) {
-                        NodeList<?> c = assertAnnotation.get().getNodeLists().get(i);
-                        for (int j = 0; j < c.size(); j++)
-                            if (c.get(j) instanceof MemberValuePair) {
-                                if (((MemberValuePair) c.get(j)).getName().equals("expected") && ((MemberValuePair) c.get(j)).getValue().toString().contains("Exception"))
-                                    ;
+                    for (Node node : assertAnnotation.get().getChildNodes()) {
+                        if (node instanceof MemberValuePair) {
+                            MemberValuePair pair = (MemberValuePair) node;
+                            if (pair.getName().getIdentifier().equals("expected")
+                                    && pair.getValue().toString().contains("Exception")) {
                                 hasExceptionAnnotation = true;
                             }
+                        }
                     }
                 }
                 currentMethod = n;

--- a/src/test/kotlin/testsmell/TestAssertionsDetection.kt
+++ b/src/test/kotlin/testsmell/TestAssertionsDetection.kt
@@ -1,6 +1,6 @@
 package testsmell
 
-import com.github.javaparser.JavaParser
+import com.github.javaparser.StaticJavaParser
 import com.github.javaparser.ast.CompilationUnit
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -19,8 +19,8 @@ class TestAssertionsDetection {
 
     @BeforeEach
     fun setup() {
-        testCompilationUnit = JavaParser.parse(simpleTest)
-        productionCompilationUnit = JavaParser.parse(simpleClass)
+        testCompilationUnit = StaticJavaParser.parse(simpleTest)
+        productionCompilationUnit = StaticJavaParser.parse(simpleClass)
         testFile = mock(TestFile::class.java)
         Mockito.`when`(testFile.testFileNameWithoutExtension).thenReturn("fake/path")
         Mockito.`when`(testFile.productionFileNameWithoutExtension).thenReturn("fake/path")

--- a/src/test/kotlin/testsmell/TestDetectionCorrectness.kt
+++ b/src/test/kotlin/testsmell/TestDetectionCorrectness.kt
@@ -1,6 +1,5 @@
 package testsmell
 
-import com.github.javaparser.JavaParser
 import com.github.javaparser.ast.CompilationUnit
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -10,6 +9,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import testsmell.smell.AssertionRoulette
 import testsmell.smell.EagerTest
+import testsmell.Util;
 import thresholds.DefaultThresholds
 import thresholds.SpadiniThresholds
 
@@ -24,8 +24,8 @@ class TestDetectionCorrectness {
 
     @BeforeEach
     fun setup() {
-        testCompilationUnit = JavaParser.parse(fractionTest)
-        productionCompilationUnit = JavaParser.parse(fractionSource)
+        testCompilationUnit = Util.parseJava(fractionTest)
+        productionCompilationUnit = Util.parseJava(fractionSource)
         testFile = mock(TestFile::class.java)
         `when`(testFile.testFileNameWithoutExtension).thenReturn("fake/path")
         `when`(testFile.productionFileNameWithoutExtension).thenReturn("fake/path")
@@ -2111,7 +2111,7 @@ class TestDetectionCorrectness {
                 f = Fraction.getFraction(-1, 1, Integer.MAX_VALUE);
                 assertEquals("-2147483648/2147483647", f.toString());
             }
-            
+
             @Test
             public void testToProperString() {
                 Fraction f;


### PR DESCRIPTION
This updates the JavaParser dependency to the most recent version to enable support for newer Java versions (up to 17 preview).

Also fixes a bug introduced in the fix to #19, where configured smells from `setTestSmells()` were overwritten.
Note that this changes `TestSmellDetector::setTestSmells(List<AbstractSmell> testSmells)` to `TestSmellDetector::setTestSmells(List<SmellFactory> testSmells)` to ensure smells can be re-initialized.